### PR TITLE
Disable unicorn/prefer-module rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -95,6 +95,10 @@ module.exports = {
         forbidDefaultForRequired: true,
         ignoreFunctionalComponents: true
       }
-    ]
+    ],
+
+    // Unicorn
+    // This disables the prefer-module as next.config.js loading does not support ESM yet.
+    'unicorn/prefer-module': 'off'
   }
 }


### PR DESCRIPTION
Next.js does not support ESM in next.config.js yet.